### PR TITLE
Updated to rand 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuss"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["gray"]
 
 # A short blurb about the package. This is not rendered in any format when
@@ -64,4 +64,7 @@ travis-ci = { repository = "surrsurus/fuss", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-rand = "0.3"
+rand = "0.6"
+
+[dev-dependencies]
+rand_xoshiro = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ travis-ci = { repository = "surrsurus/fuss", branch = "master" }
 # and `deprecated`.
 maintenance = { status = "actively-developed" }
 
+[features]
+wasm-bindgen = ["rand/wasm-bindgen"]
+
 [dependencies]
 rand = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -15,26 +15,40 @@ Add fuss to your `Cargo.toml`:
 ```toml
 [dependencies]
 # Get the current stable
-fuss = "0.2.2"
+fuss = "0.3.0"
 ```
+
+You also need a random number generator that implements `SeedableRng + RngCore` from the rand crate. For example:
+
+```toml
+[dependencies]
+# Get the current stable
+fuss = "0.3.0"
+# Get a fast, but non-cryptographic random number generator
+rand_xoshiro = "0.1"
+```
+
+The next section will use this generator in the examples.
 
 ### Examples
 
-All fuss interactions happen through the `Simplex` struct. 
+All fuss interactions happen through the `Simplex` struct.
 
 Here's how you get one:
 
 ```rust
 extern crate fuss;
+extern crate rand_xoshiro;
 use fuss::Simplex;
+use rand_xoshiro::Xoshiro256Plus;
 
-let sn = Simplex::new();
+let sn = Simplex::new::<Xoshiro256Plus>();
 ```
 
 `Simplex` lets you generate 2D and 3D noise.
 
 ```rust
-let sn = Simplex::new();
+let sn = Simplex::new::<Xoshiro256Plus>();
 sn.noise_2d(1.0, -1.0);
 sn.noise_3d(1.0, -1.0, 0.0);
 ```
@@ -42,7 +56,7 @@ sn.noise_3d(1.0, -1.0, 0.0);
 Which lets you generate noise for large sets of points:
 
 ```rust
-let sn = Simplex::new();
+let sn = Simplex::new::<Xoshiro256Plus>();
 
 let mut map = Vec::<Vec<Vec<f32>>>::new();
 for x in 0..10 {
@@ -56,18 +70,18 @@ for x in 0..10 {
 }
 ```
 
-`Simplex` generates it's own permutation table based on the rust RNG, however you can apply your own seed to get a `Simplex` as such:
+`Simplex` generates its own permutation table based on the thread-local RNG, however you can apply your own seed to get a `Simplex` as such:
 
 ```rust
-let sn = Simplex::from_seed(vec![0, 1, 2, 3, 4, 5]);
-let other_sn = Simplex::from_seed(vec![0, 1, 2, 3, 4, 5]);
+let sn = Simplex::from_seed::<Xoshiro256Plus>([0, 1, 2, 3, 4, 5, ...]);
+let other_sn = Simplex::from_seed::<Xoshiro256Plus>([0, 1, 2, 3, 4, 5, ...]);
 
 // The two simplexes will generate the same noise for the same points
 // if given the same RNG seed
 assert_eq!(sn.noise_2d(0.0, 0.0), other_sn.noise_2d(0.0, 0.0));
 ```
 
-`Simplex` uses the same type of seeds that `SeedableRng` does, being a slice of `usize`s, however to make this easier `Simplex` will accept a `Vec<usize>` instead.
+The type of the seed is `SeedableRng::Seed`, so it depends on which random number generator you're using. For `Xoshiro256Plus`, it's `[u8; 32]`.
 
 ### Running the tests
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,16 +358,18 @@ impl Simplex {
   /// # Examples
   /// 
   /// ```
+  /// extern crate rand_xoshiro;
   /// use fuss::Simplex;
-  /// 
-  /// let sn = Simplex::new();
+  /// use rand_xoshiro::Xoshiro256Plus;
+  ///
+  /// let sn = Simplex::new::<Xoshiro256Plus>();
   /// println!("{}", sn.noise_2d(50.1912, 30.50102));
   /// 
   /// // Simplex will return the same thing for the same points
   /// assert_eq!(sn.noise_3d(1.5, -0.5, 2.1), sn.noise_3d(1.5, -0.5, 2.1));
-  /// 
-  /// let other_sn = Simplex::new();
-  /// 
+  ///
+  /// let other_sn = Simplex::new::<Xoshiro256Plus>();
+  ///
   /// // However each `Simplex` has it's own set of permutations, therefore
   /// // each one is different. If you want consistency, try the `from_seed()` method.
   /// assert!(sn.noise_3d(1.5, -0.5, 2.1) != other_sn.noise_3d(1.5, -0.5, 2.1));

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,23 +1,25 @@
 #[cfg(test)]
 mod tests {
+  extern crate rand_xoshiro;
   use Simplex;
+  use self::rand_xoshiro::Xoshiro256Plus;
 
   #[test]
   fn test_simplex() {
-    let sn = Simplex::new();
+    let sn = Simplex::new::<Xoshiro256Plus>();
     sn.noise_2d(0.0, 0.0);
   }
 
   #[test]
   fn test_from_seed() {
-    let mut sn = Simplex::from_seed(vec![1, 2, 3]);
-    let mut other_sn = Simplex::from_seed(vec![1, 2, 3]);
+    let mut sn = Simplex::from_seed::<Xoshiro256Plus>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
+    let mut other_sn = Simplex::from_seed::<Xoshiro256Plus>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
 
     assert_eq!(other_sn.noise_2d(1.0, 14.2), sn.noise_2d(1.0, 14.2));
     assert_eq!(other_sn.noise_3d(1.0, 14.2, -5.4), sn.noise_3d(1.0, 14.2, -5.4));
 
-    sn = Simplex::from_seed(vec![4, 5, 6]);
-    other_sn = Simplex::from_seed(vec![1, 2, 3]);
+    sn = Simplex::from_seed::<Xoshiro256Plus>([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]);
+    other_sn = Simplex::from_seed::<Xoshiro256Plus>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32]);
 
     assert!(other_sn.noise_2d(1.0, 14.2) != sn.noise_2d(1.0, 14.2));
     assert!(other_sn.noise_3d(1.0, 14.2, -5.4) != sn.noise_3d(1.0, 14.2, -5.4));
@@ -25,7 +27,7 @@ mod tests {
 
   #[test]
   fn test_sum_octave_2d() {
-    let sn = Simplex::new();
+    let sn = Simplex::new::<Xoshiro256Plus>();
     let mut luminance = Vec::<Vec<f32>>::new();
     for x in 0..100 {
       luminance.push(Vec::<f32>::new());
@@ -37,7 +39,7 @@ mod tests {
 
   #[test]
   fn test_sum_octave_3d() {
-    let sn = Simplex::new();
+    let sn = Simplex::new::<Xoshiro256Plus>();
     let mut luminance = Vec::<Vec<Vec<f32>>>::new();
     for x in 0..10 {
       luminance.push(Vec::<Vec<f32>>::new());
@@ -52,17 +54,17 @@ mod tests {
 
   #[test]
   fn test_noise_2d() {
-    let sn = Simplex::from_seed(vec![5, 3, 2, 1, 1]);
+    let sn = Simplex::from_seed::<Xoshiro256Plus>([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]);
     assert_eq!(sn.noise_2d(1.5, -0.5), sn.noise_2d(1.5, -0.5));
-    let other_sn = Simplex::from_seed(vec![0, 1, 2, 3, 4, 5]);
+    let other_sn = Simplex::from_seed::<Xoshiro256Plus>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
     assert!(sn.noise_2d(1.5, -0.5) != other_sn.noise_2d(1.5, -0.5));
   }
 
   #[test]
   fn test_noise_3d() {
-    let sn = Simplex::from_seed(vec![5, 3, 2, 1, 1]);
+    let sn = Simplex::from_seed::<Xoshiro256Plus>([5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36]);
     assert_eq!(sn.noise_3d(1.5, -0.5, 2.1), sn.noise_3d(1.5, -0.5, 2.1));
-    let other_sn = Simplex::from_seed(vec![0, 1, 2, 3, 4, 5]);
+    let other_sn = Simplex::from_seed::<Xoshiro256Plus>([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]);
     assert!(sn.noise_3d(1.5, -0.5, 2.1) != other_sn.noise_3d(1.5, -0.5, 2.1));
   }
 


### PR DESCRIPTION
I've updated the crate to use rand 0.6 with its completely new API (since I needed it to be compatible with wasm-bindgen). This required quite a few changes, since between the version you were using and 0.6, the random number generators were generalized. This made it necessary to change the API, but it allows the caller more freedom in how to generate the permutation table.

I don't know whether you think those changes are a good idea, but I thought that creating a pull request doesn't hurt, since I had to make these adjustments anyways.